### PR TITLE
Remove joycat event

### DIFF
--- a/main.py
+++ b/main.py
@@ -142,10 +142,4 @@ async def on_message(message):
     await bot.process_commands(message)
 
 
-@bot.event
-async def on_guild_channel_update(before, after):
-    if after.id == 842947971338338326:
-        await after.edit(name="joycatboard")
-
-
 bot.run(config["token"])


### PR DESCRIPTION
Hello sir. I noticed that there is an unnecessary block of code at the bottom of your source file, something to do with a "joy cat board". It appears that this has no effect on the intended behavior of the bot, as the event only does something if it affects a specific channel ID; I'm not sure what this channel ID points to but it doesn't seem to be relevant to the intended behavior of the bot.